### PR TITLE
Add user-configurable delay to displaying data

### DIFF
--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.Designer.cs
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.Designer.cs
@@ -89,11 +89,14 @@
             this.label12 = new System.Windows.Forms.Label();
             this.lblHelp = new System.Windows.Forms.Label();
             this.tabPage4 = new System.Windows.Forms.TabPage();
+            this.chkAutoUpdateEnabledOnStartup = new System.Windows.Forms.CheckBox();
             this.label19 = new System.Windows.Forms.Label();
             this.label18 = new System.Windows.Forms.Label();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.tabPage3 = new System.Windows.Forms.TabPage();
-            this.chkAutoUpdateEnabledOnStartup = new System.Windows.Forms.CheckBox();
+            this.chkDelayDataUpdates = new System.Windows.Forms.CheckBox();
+            this.txtDataDelay = new System.Windows.Forms.TextBox();
+            this.lblDataDelay = new System.Windows.Forms.Label();
             this.panel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -750,6 +753,9 @@
             // 
             // tabPage4
             // 
+            this.tabPage4.Controls.Add(this.lblDataDelay);
+            this.tabPage4.Controls.Add(this.txtDataDelay);
+            this.tabPage4.Controls.Add(this.chkDelayDataUpdates);
             this.tabPage4.Controls.Add(this.chkAutoUpdateEnabledOnStartup);
             this.tabPage4.Controls.Add(this.label19);
             this.tabPage4.Controls.Add(this.label18);
@@ -771,6 +777,16 @@
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "UI Options";
             this.tabPage4.UseVisualStyleBackColor = true;
+            // 
+            // chkAutoUpdateEnabledOnStartup
+            // 
+            this.chkAutoUpdateEnabledOnStartup.AutoSize = true;
+            this.chkAutoUpdateEnabledOnStartup.Location = new System.Drawing.Point(14, 325);
+            this.chkAutoUpdateEnabledOnStartup.Name = "chkAutoUpdateEnabledOnStartup";
+            this.chkAutoUpdateEnabledOnStartup.Size = new System.Drawing.Size(244, 24);
+            this.chkAutoUpdateEnabledOnStartup.TabIndex = 23;
+            this.chkAutoUpdateEnabledOnStartup.Text = "Auto-Update enabled on startup";
+            this.chkAutoUpdateEnabledOnStartup.UseVisualStyleBackColor = true;
             // 
             // label19
             // 
@@ -824,15 +840,35 @@
             this.tabPage3.Text = "Folders";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
-            // chkAutoUpdateEnabledOnStartup
+            // chkDelayDataUpdates
             // 
-            this.chkAutoUpdateEnabledOnStartup.AutoSize = true;
-            this.chkAutoUpdateEnabledOnStartup.Location = new System.Drawing.Point(14, 325);
-            this.chkAutoUpdateEnabledOnStartup.Name = "chkAutoUpdateEnabledOnStartup";
-            this.chkAutoUpdateEnabledOnStartup.Size = new System.Drawing.Size(244, 24);
-            this.chkAutoUpdateEnabledOnStartup.TabIndex = 23;
-            this.chkAutoUpdateEnabledOnStartup.Text = "Auto-Update enabled on startup";
-            this.chkAutoUpdateEnabledOnStartup.UseVisualStyleBackColor = true;
+            this.chkDelayDataUpdates.AutoSize = true;
+            this.chkDelayDataUpdates.Location = new System.Drawing.Point(14, 355);
+            this.chkDelayDataUpdates.Name = "chkDelayDataUpdates";
+            this.chkDelayDataUpdates.Size = new System.Drawing.Size(157, 24);
+            this.chkDelayDataUpdates.TabIndex = 24;
+            this.chkDelayDataUpdates.Text = "Delay data updates";
+            this.chkDelayDataUpdates.UseVisualStyleBackColor = true;
+            this.chkDelayDataUpdates.CheckStateChanged += new System.EventHandler(this.chkDelayDataUpdates_CheckStateChanged);
+            // 
+            // txtDataDelay
+            // 
+            this.txtDataDelay.Enabled = false;
+            this.txtDataDelay.Location = new System.Drawing.Point(34, 385);
+            this.txtDataDelay.Name = "txtDataDelay";
+            this.txtDataDelay.Size = new System.Drawing.Size(52, 27);
+            this.txtDataDelay.TabIndex = 25;
+            this.txtDataDelay.Text = "0";
+            // 
+            // lblDataDelay
+            // 
+            this.lblDataDelay.AutoSize = true;
+            this.lblDataDelay.Enabled = false;
+            this.lblDataDelay.Location = new System.Drawing.Point(92, 388);
+            this.lblDataDelay.Name = "lblDataDelay";
+            this.lblDataDelay.Size = new System.Drawing.Size(122, 20);
+            this.lblDataDelay.TabIndex = 26;
+            this.lblDataDelay.Text = "Delay in Seconds";
             // 
             // UserSettingsDialog
             // 
@@ -939,5 +975,8 @@
         private System.Windows.Forms.Label label19;
         private System.Windows.Forms.Label label18;
         private System.Windows.Forms.CheckBox chkAutoUpdateEnabledOnStartup;
+        private System.Windows.Forms.CheckBox chkDelayDataUpdates;
+        private System.Windows.Forms.Label lblDataDelay;
+        private System.Windows.Forms.TextBox txtDataDelay;
     }
 }

--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.cs
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.cs
@@ -89,6 +89,11 @@ namespace rNascar23.Dialogs
             chkUseGraphicalNumbers.Checked = settings.UseGraphicalCarNumbers;
             chkUseDarkTheme.Checked = settings.UseDarkTheme;
             chkAutoUpdateEnabledOnStartup.Checked = settings.AutoUpdateEnabledOnStart;
+            chkDelayDataUpdates.Checked = settings.DataDelayInSeconds.HasValue;
+            if (settings.DataDelayInSeconds.HasValue)
+            {
+                txtDataDelay.Text = settings.DataDelayInSeconds.Value.ToString();
+            }
 
             DisplayFavoriteDrivers(settings.FavoriteDrivers);
 
@@ -352,7 +357,8 @@ namespace rNascar23.Dialogs
         {
             try
             {
-                UpdateUserSettings();
+                if (!UpdateUserSettings())
+                    return;
 
                 UserSettingsService.SaveUserSettings(_userSettings);
 
@@ -365,8 +371,33 @@ namespace rNascar23.Dialogs
             }
         }
 
-        private void UpdateUserSettings()
+        private bool UpdateUserSettings()
         {
+            if (chkDelayDataUpdates.Checked)
+            {
+                if (String.IsNullOrEmpty(txtDataDelay.Text))
+                    _userSettings.DataDelayInSeconds = null;
+                else if (int.TryParse(txtDataDelay.Text, out int dataDelay))
+                {
+                    if (dataDelay < 0)
+                    {
+                        MessageBox.Show("Data delay value must be greater than zero");
+                        return false;
+                    }
+                    else if (dataDelay == 0)
+                        _userSettings.DataDelayInSeconds = null;
+                    else
+                        _userSettings.DataDelayInSeconds = dataDelay;
+                }
+                else
+                {
+                    MessageBox.Show("Data delay value must be numeric");
+                    return false;
+                }
+            }
+            else
+                _userSettings.DataDelayInSeconds = null;
+
             _userSettings.BackupDirectory = txtBackupDirectory.Text;
             _userSettings.DataDirectory = txtDataDirectory.Text;
             _userSettings.LogDirectory = txtLogDirectory.Text;
@@ -390,6 +421,8 @@ namespace rNascar23.Dialogs
             }
 
             UpdateUserSelectedViews();
+
+            return true;
         }
 
         private void UpdateUserSelectedViews()
@@ -428,6 +461,12 @@ namespace rNascar23.Dialogs
 
                 lblHelp.Text = viewDetail.Description;
             }
+        }
+
+        private void chkDelayDataUpdates_CheckStateChanged(object sender, EventArgs e)
+        {
+            txtDataDelay.Enabled = chkDelayDataUpdates.Checked;
+            lblDataDelay.Enabled = chkDelayDataUpdates.Checked;
         }
 
         #endregion

--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.resx
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.resx
@@ -181,6 +181,9 @@
         gg==
 </value>
   </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="btnBackupDirectory.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6

--- a/src/apps/rNascar23/MainForm.cs
+++ b/src/apps/rNascar23/MainForm.cs
@@ -96,6 +96,7 @@ namespace rNascar23
         private FormState _formState = new FormState();
         private bool _isFullScreen = false;
         private bool _isImportedData = false;
+        private int? _dataDelayInSeconds = null;
         private FormWindowState _windowState = FormWindowState.Normal;
 
         private LapStateViewModel _lapStates = new LapStateViewModel();
@@ -179,6 +180,8 @@ namespace rNascar23
                 await DisplayTodaysScheduleAsync(true);
 
                 var settings = UserSettingsService.LoadUserSettings();
+
+                _dataDelayInSeconds = settings.DataDelayInSeconds;
 
                 if (settings.AutoUpdateEnabledOnStart)
                 {
@@ -788,6 +791,11 @@ namespace rNascar23
             _formState.PitStops = await _pitStopsRepository.GetPitStopsAsync(_formState.LiveFeed.SeriesId, _formState.LiveFeed.RaceId);
 
             _formState.KeyMoments = await _keyMomentsRepository.GetKeyMomentsAsync(_formState.LiveFeed.SeriesId, _formState.LiveFeed.RaceId);
+
+            if (_dataDelayInSeconds.HasValue)
+            {
+                await Task.Delay(_dataDelayInSeconds.Value * 1000);
+            }
 
             return true;
         }
@@ -2738,6 +2746,8 @@ namespace rNascar23
             if (result == DialogResult.OK)
             {
                 _logger.LogInformation("User settings updated");
+
+                _dataDelayInSeconds = dialog.UserSettings.DataDelayInSeconds;
 
                 var viewState = _viewState;
 

--- a/src/libraries/Common/rNasar23.Common/UserSettings.cs
+++ b/src/libraries/Common/rNasar23.Common/UserSettings.cs
@@ -23,5 +23,6 @@ namespace rNascar23.Common
         public IList<int> QualifyingViewRightGrids { get; set; } = new List<int>();
         public IList<int> PracticeViewBottomGrids { get; set; } = new List<int>();
         public IList<int> PracticeViewRightGrids { get; set; } = new List<int>();
+        public int? DataDelayInSeconds { get; set; } = null;
     }
 }


### PR DESCRIPTION
Add user-configurable delay to displaying data, so that users can sync the application with their video source.