### PR TITLE
Schedules and PitStops view don't respond to theme change

### DIFF
--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 // BUILD IN RELEASE MODE FOR PATCH/RELEASE!
-[assembly: AssemblyVersion("0.3.0.26")]
-[assembly: AssemblyFileVersion("0.3.0.26")]
+[assembly: AssemblyVersion("0.3.0.27")]
+[assembly: AssemblyFileVersion("0.3.0.27")]

--- a/src/apps/rNascar23/MainForm.cs
+++ b/src/apps/rNascar23/MainForm.cs
@@ -2150,6 +2150,12 @@ namespace rNascar23
                 if (pnlMain.Controls.Count > 0)
                     pnlMain.Controls.Clear();
 
+                if (pnlSchedules.Controls.Count > 0)
+                    pnlSchedules.Controls.Clear();
+
+                if (pnlPitStops.Controls.Count > 0)
+                    pnlPitStops.Controls.Clear();
+
                 var viewState = _viewState;
 
                 await SetViewStateAsync(ViewState.None, true);


### PR DESCRIPTION
Added logic to force a reload of the schedule and pitstops views when the user updated their settings.