### PR TITLE
Revise panel z-order logic

### DIFF
--- a/src/apps/rNascar23/Dialogs/AudioPlayer.cs
+++ b/src/apps/rNascar23/Dialogs/AudioPlayer.cs
@@ -56,7 +56,9 @@ namespace rNascar23.Dialogs
             _mediaRepository = mediaRepository ?? throw new ArgumentNullException(nameof(mediaRepository));
 
             LogInfoMessage("before InitializeBrowserAsync");
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             InitializeBrowserAsync();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             LogInfoMessage("after InitializeBrowserAsync");
         }
 

--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.cs
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using rNascar23.Common;
 using rNascar23.LoopData.Ports;
 using rNascar23.Views;
@@ -20,10 +21,11 @@ namespace rNascar23.Dialogs
         private readonly ILogger<UserSettingsDialog> _logger = null;
         private readonly IDriverInfoRepository _driverRepository = null;
         private Font _overrideFont = null;
+        private string _originalUserSettingsJson = String.Empty;
 
         #endregion
 
-        #region private properties
+        #region properties
 
         private UserSettings _userSettings = null;
         public UserSettings UserSettings
@@ -35,6 +37,25 @@ namespace rNascar23.Dialogs
             set
             {
                 _userSettings = value;
+            }
+        }
+
+        public bool UserSettingsHasChanges
+        {
+            get
+            {
+                try
+                {
+                    var userSettingsJson = JsonConvert.SerializeObject(_userSettings);
+
+                    return !_originalUserSettingsJson.Equals(userSettingsJson, StringComparison.InvariantCultureIgnoreCase);
+                }
+                catch (Exception ex)
+                {
+                    ExceptionHandler(ex);
+                }
+
+                return true;
             }
         }
 
@@ -64,6 +85,8 @@ namespace rNascar23.Dialogs
                 LoadAvailableViews();
 
                 DisplayUserSettings(_userSettings);
+
+                RecordUserSettingsState();
             }
             catch (Exception ex)
             {
@@ -177,7 +200,7 @@ namespace rNascar23.Dialogs
                 chkQualifyingViewsBottom.Items.Add(viewDetail);
                 chkPracticeViewsBottom.Items.Add(viewDetail);
 
-                if (viewDetail.ViewType != GridViewTypes.Flags)
+                if (viewDetail.ViewType != GridViewTypes.Flags && viewDetail.ViewType != GridViewTypes.KeyMoments)
                 {
                     chkRaceViewsRight.Items.Add(viewDetail);
                     chkQualifyingViewsRight.Items.Add(viewDetail);
@@ -543,6 +566,11 @@ namespace rNascar23.Dialogs
                 lblOverrideFont.Text = $"{overrideFont.Name}; Size = {overrideFont.Size}; Style = {overrideFont.Style}";
                 lblOverrideFont.Font = overrideFont;
             }
+        }
+
+        private void RecordUserSettingsState()
+        {
+            _originalUserSettingsJson = JsonConvert.SerializeObject(_userSettings);
         }
 
         #endregion

--- a/src/apps/rNascar23/Dialogs/VideoPlayer.cs
+++ b/src/apps/rNascar23/Dialogs/VideoPlayer.cs
@@ -56,7 +56,9 @@ namespace rNascar23.Dialogs
             _mediaRepository = mediaRepository ?? throw new ArgumentNullException(nameof(mediaRepository));
 
             LogInfoMessage("before InitializeBrowserAsync");
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             InitializeBrowserAsync();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             LogInfoMessage("after InitializeBrowserAsync");
         }
 

--- a/src/apps/rNascar23/Logic/FlagUiColors.cs
+++ b/src/apps/rNascar23/Logic/FlagUiColors.cs
@@ -1,0 +1,15 @@
+﻿using System.Drawing;
+
+namespace rNascar23.Logic
+{
+    internal static class FlagUiColors
+    {
+        public static Color Green = Color.Green;
+        public static Color Yellow = Color.Gold;
+        public static Color Red = Color.Red;
+        public static Color White = Color.White;
+        public static Color Checkered = Color.Gray;
+        public static Color HotTrack = Color.DarkOrange;
+        public static Color ColdTrack = Color.CornflowerBlue;
+    }
+}

--- a/src/apps/rNascar23/MainForm.Designer.cs
+++ b/src/apps/rNascar23/MainForm.Designer.cs
@@ -44,6 +44,7 @@
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.logFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.patchNotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.localDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.importDumpFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.replayEventToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -93,7 +94,8 @@
             this.pnlSchedules = new System.Windows.Forms.Panel();
             this.timEventReplay = new System.Windows.Forms.Timer(this.components);
             this.pnlPitStops = new System.Windows.Forms.Panel();
-            this.patchNotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pnlLoading = new System.Windows.Forms.Panel();
+            this.lblLoading = new System.Windows.Forms.Label();
             this.pnlHeader.SuspendLayout();
             this.pnlEventInfo.SuspendLayout();
             this.pnlFlagGreenYellow.SuspendLayout();
@@ -102,6 +104,7 @@
             this.menuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
+            this.pnlLoading.SuspendLayout();
             this.SuspendLayout();
             // 
             // pnlHeader
@@ -242,9 +245,16 @@
             // 
             this.logFileToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("logFileToolStripMenuItem.Image")));
             this.logFileToolStripMenuItem.Name = "logFileToolStripMenuItem";
-            this.logFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.logFileToolStripMenuItem.Size = new System.Drawing.Size(138, 22);
             this.logFileToolStripMenuItem.Text = "Log File";
             this.logFileToolStripMenuItem.Click += new System.EventHandler(this.logFileToolStripMenuItem_Click);
+            // 
+            // patchNotesToolStripMenuItem
+            // 
+            this.patchNotesToolStripMenuItem.Name = "patchNotesToolStripMenuItem";
+            this.patchNotesToolStripMenuItem.Size = new System.Drawing.Size(138, 22);
+            this.patchNotesToolStripMenuItem.Text = "Patch Notes";
+            this.patchNotesToolStripMenuItem.Click += new System.EventHandler(this.patchNotesToolStripMenuItem_Click);
             // 
             // localDataToolStripMenuItem
             // 
@@ -693,12 +703,27 @@
             this.pnlPitStops.TabIndex = 11;
             this.pnlPitStops.Visible = false;
             // 
-            // patchNotesToolStripMenuItem
+            // pnlLoading
             // 
-            this.patchNotesToolStripMenuItem.Name = "patchNotesToolStripMenuItem";
-            this.patchNotesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.patchNotesToolStripMenuItem.Text = "Patch Notes";
-            this.patchNotesToolStripMenuItem.Click += new System.EventHandler(this.patchNotesToolStripMenuItem_Click);
+            this.pnlLoading.BackColor = System.Drawing.Color.Black;
+            this.pnlLoading.Controls.Add(this.lblLoading);
+            this.pnlLoading.Font = new System.Drawing.Font("Snyder Speed Brush", 20.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.pnlLoading.Location = new System.Drawing.Point(0, 4);
+            this.pnlLoading.Name = "pnlLoading";
+            this.pnlLoading.Size = new System.Drawing.Size(13, 20);
+            this.pnlLoading.TabIndex = 12;
+            this.pnlLoading.Visible = false;
+            // 
+            // lblLoading
+            // 
+            this.lblLoading.AutoSize = true;
+            this.lblLoading.BackColor = System.Drawing.Color.Black;
+            this.lblLoading.ForeColor = System.Drawing.Color.Silver;
+            this.lblLoading.Location = new System.Drawing.Point(603, 292);
+            this.lblLoading.Name = "lblLoading";
+            this.lblLoading.Size = new System.Drawing.Size(133, 33);
+            this.lblLoading.TabIndex = 0;
+            this.lblLoading.Text = "Loading...";
             // 
             // MainForm
             // 
@@ -706,6 +731,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.ClientSize = new System.Drawing.Size(1350, 729);
+            this.Controls.Add(this.pnlLoading);
             this.Controls.Add(this.pnlMain);
             this.Controls.Add(this.pnlBottom);
             this.Controls.Add(this.pnlRight);
@@ -724,6 +750,7 @@
             this.Text = "rNASCAR23";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
             this.Load += new System.EventHandler(this.MainForm_Load);
+            this.ResizeEnd += new System.EventHandler(this.MainForm_ResizeEnd);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MainForm_KeyDown);
             this.pnlHeader.ResumeLayout(false);
             this.pnlEventInfo.ResumeLayout(false);
@@ -737,6 +764,8 @@
             this.statusStrip1.PerformLayout();
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();
+            this.pnlLoading.ResumeLayout(false);
+            this.pnlLoading.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -807,6 +836,8 @@
         private System.Windows.Forms.ToolStripMenuItem inCarCamerasToolStripMenuItem;
         private System.Windows.Forms.Panel pnlPitStops;
         private System.Windows.Forms.ToolStripMenuItem patchNotesToolStripMenuItem;
+        private System.Windows.Forms.Panel pnlLoading;
+        private System.Windows.Forms.Label lblLoading;
     }
 }
 

--- a/src/apps/rNascar23/ViewModels/LapStateViewModel.cs
+++ b/src/apps/rNascar23/ViewModels/LapStateViewModel.cs
@@ -1,21 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using rNascar23.Flags.Models;
+using System.Collections.Generic;
 
 namespace rNascar23.ViewModels
 {
     internal class LapStateViewModel
     {
-        public enum FlagState
-        {
-            None = 0,
-            Green = 1,
-            Yellow = 2,
-            Red = 3,
-            White = 4,
-            Checkered = 5,
-            Hot = 8,
-            Cold = 9
-        }
-
         public int Stage1Laps { get; set; }
         public int Stage2Laps { get; set; }
         public int Stage3Laps { get; set; }
@@ -26,7 +15,7 @@ namespace rNascar23.ViewModels
             public int StartLapNumber { get; set; }
             public int Laps { get; set; }
             public int Stage { get; set; }
-            public FlagState FlagState { get; set; }
+            public FlagColors FlagState { get; set; }
 
             public override string ToString()
             {

--- a/src/apps/rNascar23/Views/FlagsView.Designer.cs
+++ b/src/apps/rNascar23/Views/FlagsView.Designer.cs
@@ -41,6 +41,7 @@
             // FlagsView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.DoubleBuffered = true;
             this.Name = "FlagsView";
             this.Size = new System.Drawing.Size(451, 228);
             ((System.ComponentModel.ISupportInitialize)(this.GridBindingSource)).EndInit();

--- a/src/apps/rNascar23/Views/GridView.Designer.cs
+++ b/src/apps/rNascar23/Views/GridView.Designer.cs
@@ -62,6 +62,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.Grid);
             this.Controls.Add(this.TitleLabel);
+            this.DoubleBuffered = true;
             this.Name = "GridView";
             this.Size = new System.Drawing.Size(418, 331);
             ((System.ComponentModel.ISupportInitialize)(this.Grid)).EndInit();

--- a/src/apps/rNascar23/Views/GridViewBase.cs
+++ b/src/apps/rNascar23/Views/GridViewBase.cs
@@ -145,7 +145,7 @@ namespace rNascar23.Views
                 GridStyle = new GridStyle()
                 {
                     BackColor = Color.WhiteSmoke.ToArgb(),
-                    LineColor = Color.Gray.ToArgb(),
+                    LineColor = Color.WhiteSmoke.ToArgb(),
                 },
                 HeaderStyle = new GridRowStyle()
                 {

--- a/src/apps/rNascar23/Views/KeyMomentsView.Designer.cs
+++ b/src/apps/rNascar23/Views/KeyMomentsView.Designer.cs
@@ -38,10 +38,11 @@
             this.TitleLabel.Size = new System.Drawing.Size(451, 23);
             this.TitleLabel.Text = "Basic Grid";
             // 
-            // FlagsView
+            // KeyMomentsView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.Name = "FlagsView";
+            this.DoubleBuffered = true;
+            this.Name = "KeyMomentsView";
             this.Size = new System.Drawing.Size(451, 228);
             ((System.ComponentModel.ISupportInitialize)(this.GridBindingSource)).EndInit();
             this.ResumeLayout(false);

--- a/src/apps/rNascar23/Views/KeyMomentsView.cs
+++ b/src/apps/rNascar23/Views/KeyMomentsView.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using rNascar23.Flags.Models;
+using rNascar23.Logic;
+using System.Collections.Generic;
 using System.Data;
 using System.Drawing;
 using System.Linq;
@@ -6,8 +8,17 @@ using System.Windows.Forms;
 
 namespace rNascar23.Views
 {
-    public partial class KeyMomentsView : rNascar23.Views.GridViewBase
+    public partial class KeyMomentsView : GridViewBase
     {
+        #region consts
+
+        private const int LapNumberColumnIndex = 1;
+        private const int FlagStateColumnIndex = 2;
+
+        #endregion
+
+        #region ctor
+
         public KeyMomentsView()
         {
             InitializeComponent();
@@ -15,26 +26,27 @@ namespace rNascar23.Views
             Grid.RowsAdded += Grid_RowsAdded;
         }
 
+        #endregion
+
+        #region protected
+
         protected override void AddColumns()
         {
-            DataGridViewTextBoxColumn Column1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn colFlagColor = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn colNoteId = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn colLapNumber = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn colFlagColor = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn colNote = new DataGridViewTextBoxColumn();
 
-            Grid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[]
+            Grid.Columns.AddRange(new DataGridViewColumn[]
             {
-                Column1,
-                Column2,
-                Column3,
+                colNoteId,
+                colLapNumber,
                 colFlagColor,
-                Column4,
+                colNote,
             });
 
-            GridViewColumnBuilder.ConfigureColumn(Column1, "NoteId", 50, "NoteId");
-            GridViewColumnBuilder.ConfigureColumn(Column2, "LapNumber", 35, "Lap");
-            GridViewColumnBuilder.ConfigureColumn(Column3, "FlagState", 50, "State");
+            GridViewColumnBuilder.ConfigureColumn(colNoteId, "NoteId", 50, "NoteId");
+            GridViewColumnBuilder.ConfigureColumn(colLapNumber, "LapNumber", 35, "Lap");
 
             colFlagColor.HeaderText = "";
             colFlagColor.Name = "FlagColor";
@@ -42,7 +54,7 @@ namespace rNascar23.Views
             colFlagColor.Visible = true;
             colFlagColor.DefaultCellStyle.BackColor = Color.White;
 
-            GridViewColumnBuilder.ConfigureColumn(Column4, "Note", 275);
+            GridViewColumnBuilder.ConfigureColumn(colNote, "Note", 200);
 
             Grid.ColumnHeadersVisible = true;
             Grid.RowHeadersVisible = false;
@@ -53,8 +65,11 @@ namespace rNascar23.Views
             Grid.SelectionChanged += (s, e) => Grid.ClearSelection();
             Grid.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
             Grid.DefaultCellStyle.WrapMode = DataGridViewTriState.True;
-            Grid.CellBorderStyle = DataGridViewCellBorderStyle.Single;
         }
+
+        #endregion
+
+        #region public
 
         public override void SetDataSource<TModel>(IList<TModel> models)
         {
@@ -66,7 +81,7 @@ namespace rNascar23.Views
                     Take(Settings.MaxRows.Value).
                     ToList();
 
-            _dataTable = GridViewTableBuilder.ToDataTable<TModel>(models.ToList());
+            _dataTable = GridViewTableBuilder.ToDataTable(models.ToList());
 
             var dataView = new DataView(_dataTable);
 
@@ -78,6 +93,10 @@ namespace rNascar23.Views
                 Grid.FirstDisplayedScrollingRowIndex = Grid.RowCount - 1;
         }
 
+        #endregion
+
+        #region private
+
         private void Grid_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)
         {
             var grid = sender as DataGridView;
@@ -86,42 +105,52 @@ namespace rNascar23.Views
             {
                 var row = grid.Rows[i];
 
-                if (row.Cells[2].Value != null)
+                row.DividerHeight = 10;
+
+                if (row.Cells[FlagStateColumnIndex].Value != null)
                 {
-                    if (int.Parse(row.Cells[2].Value.ToString()) == 1)
+                    if (int.Parse(row.Cells[FlagStateColumnIndex].Value.ToString()) == (int)FlagColors.Green)
                     {
-                        row.Cells[3].Style.BackColor = Color.Green;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = FlagUiColors.Green;
+                        row.Cells[LapNumberColumnIndex].Style.ForeColor = Color.White;
                     }
-                    else if (int.Parse(row.Cells[2].Value.ToString()) == 2)
+                    else if (int.Parse(row.Cells[FlagStateColumnIndex].Value.ToString()) == (int)FlagColors.Yellow)
                     {
-                        row.Cells[3].Style.BackColor = Color.Gold;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = FlagUiColors.Yellow;
+                        row.Cells[LapNumberColumnIndex].Style.ForeColor = Color.Black;
                     }
-                    else if (int.Parse(row.Cells[2].Value.ToString()) == 3)
+                    else if (int.Parse(row.Cells[FlagStateColumnIndex].Value.ToString()) == (int)FlagColors.Red)
                     {
-                        row.Cells[3].Style.BackColor = Color.Red;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = FlagUiColors.Red;
+                        row.Cells[LapNumberColumnIndex].Style.ForeColor = Color.Black;
                     }
-                    else if (int.Parse(row.Cells[2].Value.ToString()) == 4)
+                    else if (int.Parse(row.Cells[FlagStateColumnIndex].Value.ToString()) == (int)FlagColors.White)
                     {
-                        row.Cells[3].Style.BackColor = Color.White;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = FlagUiColors.White;
+                        row.Cells[LapNumberColumnIndex].Style.ForeColor = Color.Black;
                     }
-                    else if (int.Parse(row.Cells[2].Value.ToString()) == 8)
+                    else if (int.Parse(row.Cells[FlagStateColumnIndex].Value.ToString()) == (int)FlagColors.HotTrack)
                     {
-                        row.Cells[3].Style.BackColor = Color.Orange;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = FlagUiColors.HotTrack;
+                        row.Cells[LapNumberColumnIndex].Style.ForeColor = Color.Black;
                     }
-                    else if (int.Parse(row.Cells[2].Value.ToString()) == 9)
+                    else if (int.Parse(row.Cells[FlagStateColumnIndex].Value.ToString()) == (int)FlagColors.ColdTrack)
                     {
-                        row.Cells[3].Style.BackColor = Color.CornflowerBlue;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = FlagUiColors.ColdTrack;
+                        row.Cells[LapNumberColumnIndex].Style.ForeColor = Color.Black;
                     }
                     else
                     {
-                        row.Cells[3].Style.BackColor = row.Cells[0].Style.BackColor;
+                        row.Cells[LapNumberColumnIndex].Style.BackColor = row.Cells[FlagStateColumnIndex].Style.BackColor;
                     }
                 }
                 else
                 {
-                    row.Cells[3].Style.BackColor = row.Cells[0].Style.BackColor;
+                    row.Cells[2].Style.BackColor = row.Cells[FlagStateColumnIndex].Style.BackColor;
                 }
             }
         }
+
+        #endregion
     }
 }

--- a/src/apps/rNascar23/Views/ViewFactory.cs
+++ b/src/apps/rNascar23/Views/ViewFactory.cs
@@ -1,5 +1,6 @@
 ﻿using rNascar23.Common;
 using rNascar23.CustomViews;
+using rNascar23.Logic;
 using System.Collections.Generic;
 using System.Drawing;
 
@@ -233,7 +234,7 @@ namespace rNascar23.Views
                 case GridViewTypes.Best5Laps:
                 case GridViewTypes.Best10Laps:
                 case GridViewTypes.Best15Laps:
-                    view.Settings.Columns[1].Width = 125; // driver name column
+                    view.Settings.Columns[1].Width = 120; // driver name column
                     view.Settings.TitleBackColor = Color.CornflowerBlue;
                     view.Settings.TitleForeColor = Color.Black;
                     break;
@@ -241,7 +242,7 @@ namespace rNascar23.Views
                 case GridViewTypes.Last5Laps:
                 case GridViewTypes.Last10Laps:
                 case GridViewTypes.Last15Laps:
-                    view.Settings.Columns[1].Width = 125; // driver name column
+                    view.Settings.Columns[1].Width = 120; // driver name column
                     view.Settings.TitleBackColor = Color.RoyalBlue;
                     view.Settings.TitleForeColor = Color.White;
                     break;
@@ -267,9 +268,7 @@ namespace rNascar23.Views
                     view.Settings = new GridSettings()
                     {
                         MaxRows = null,
-                        ViewWidth = 475,
-                        GridWidth = 450,
-                        TitleBackColor = Color.Gold,
+                        TitleBackColor = FlagUiColors.Yellow,
                         TitleForeColor = Color.Black,
                         Title = "Flags",
                         HideColumnHeaders = false,
@@ -281,68 +280,41 @@ namespace rNascar23.Views
                                 Index= 0,
                                 DataProperty = "State",
                                 DisplayIndex= 0,
-                                HeaderTitle ="State",
                                 Visible =false,
                                 Width = 60
                             },
                             new GridColumnSettings()
                             {
                                 Index= 1,
+                                DataProperty = "LapNumber",
                                 DisplayIndex= 1,
-                                HeaderTitle ="Flag",
+                                HeaderTitle ="Lap",
                                 Visible =true,
-                                Width = 35
+                                Width = 38
                             },
                             new GridColumnSettings()
                             {
                                 Index= 2,
-                                DataProperty = "LapNumber",
+                                DataProperty = "Comment",
                                 DisplayIndex= 2,
-                                HeaderTitle ="Lap",
+                                HeaderTitle ="Caution For",
                                 Visible =true,
-                                Width = 40
+                                Width = 150,
                             },
                             new GridColumnSettings()
                             {
                                 Index= 3,
-                                DataProperty = "Comment",
+                                DataProperty = "Beneficiary",
                                 DisplayIndex= 3,
-                                HeaderTitle ="Caution For",
+                                HeaderTitle ="Pass",
                                 Visible =true,
-                                Width = 175,
+                                Width = 38,
                             },
                             new GridColumnSettings()
                             {
                                 Index= 4,
-                                DataProperty = "Beneficiary",
-                                DisplayIndex= 4,
-                                HeaderTitle ="Lucky Dog",
-                                Visible =true,
-                                Width = 55,
-                            },
-                            new GridColumnSettings()
-                            {
-                                Index= 5,
-                                DataProperty = "ElapsedTime",
-                                DisplayIndex= 5,
-                                HeaderTitle ="ElapsedTime",
-                                Visible =false,
-                                Width = 150,
-                            },
-                            new GridColumnSettings()
-                            {
-                                Index= 6,
-                                DataProperty = "TimeOfDay",
-                                DisplayIndex= 6,
-                                HeaderTitle ="TimeOfDay",
-                                Visible =false,
-                                Width = 150,
-                            },
-                            new GridColumnSettings()
-                            {
-                                Index= 7,
                                 DataProperty = "TimeOfDayOs",
-                                DisplayIndex= 7,
+                                DisplayIndex= 4,
                                 HeaderTitle ="Time",
                                 Visible =true,
                                 Width = 70,
@@ -359,8 +331,6 @@ namespace rNascar23.Views
                     view.Settings = new GridSettings()
                     {
                         MaxRows = null,
-                        ViewWidth = 475,
-                        GridWidth = 450,
                         TitleBackColor = Color.Magenta,
                         TitleForeColor = Color.Black,
                         Title = "Key Moments",
@@ -384,7 +354,7 @@ namespace rNascar23.Views
                                 DisplayIndex= 1,
                                 HeaderTitle ="Lap",
                                 Visible =true,
-                                Width = 45
+                                Width = 38
                             },
                             new GridColumnSettings()
                             {
@@ -398,19 +368,10 @@ namespace rNascar23.Views
                             new GridColumnSettings()
                             {
                                 Index= 3,
-                                DisplayIndex= 3,
-                                HeaderTitle ="Flag",
-                                Visible =true,
-                                Width = 40,
-                            },
-                            new GridColumnSettings()
-                            {
-                                Index= 4,
                                 DataProperty = "Note",
-                                DisplayIndex= 4,
-                                HeaderTitle ="Note",
+                                DisplayIndex= 3,
                                 Visible =true,
-                                Width = 500,
+                                Width = 280,
                             }
                         },
                         SortOrderField = "NoteId",

--- a/src/apps/rNascar23/rNascar23.csproj
+++ b/src/apps/rNascar23/rNascar23.csproj
@@ -272,6 +272,7 @@
     <Compile Include="CustomViews\ApiSources.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Logic\DayOfWeekHelper.cs" />
+    <Compile Include="Logic\FlagUiColors.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/libraries/Flags/rNascar23.Flags/Models/FlagColors.cs
+++ b/src/libraries/Flags/rNascar23.Flags/Models/FlagColors.cs
@@ -1,0 +1,16 @@
+﻿namespace rNascar23.Flags.Models
+{
+    public enum FlagColors
+    {
+        None = 0,
+        Green = 1,
+        Yellow = 2,
+        Red = 3,
+        White = 4,
+        Checkered = 5,
+        FlagColor6 = 6,
+        FlagColor7 = 7,
+        HotTrack = 8,
+        ColdTrack = 9
+    }
+}

--- a/src/libraries/Flags/rNascar23.Flags/Models/FlagState.cs
+++ b/src/libraries/Flags/rNascar23.Flags/Models/FlagState.cs
@@ -5,7 +5,7 @@ namespace rNascar23.Flags.Models
     public class FlagState
     {
         public int LapNumber { get; set; }
-        public int State { get; set; }
+        public FlagColors State { get; set; }
         public float ElapsedTime { get; set; }
         public string Comment { get; set; }
         public string Beneficiary { get; set; }

--- a/src/libraries/Flags/rNascar23.Service.Flags/Mappings/FlagStateMappingProfile.cs
+++ b/src/libraries/Flags/rNascar23.Service.Flags/Mappings/FlagStateMappingProfile.cs
@@ -10,7 +10,7 @@ namespace rNascar23.Service.Flags.Mappings
         {
             CreateMap<FlagStateModel, FlagState>()
            .ForMember(m => m.LapNumber, opts => opts.MapFrom(src => src.lap_number))
-           .ForMember(m => m.State, opts => opts.MapFrom(src => src.flag_state))
+           .ForMember(m => m.State, opts => opts.MapFrom(src => (FlagColors)src.flag_state))
            .ForMember(m => m.ElapsedTime, opts => opts.MapFrom(src => src.elapsed_time))
            .ForMember(m => m.Comment, opts => opts.MapFrom(src => src.comment))
            .ForMember(m => m.Beneficiary, opts => opts.MapFrom(src => src.beneficiary))


### PR DESCRIPTION
- Fixed a bug where the right and bottom panel z-orders would get out of sync.
- Added loading screen
- Revised Flags and Key Moments grids to be more compact.
- Added logic to resize grids in the right panel to prevent having a scrollbar, if there were more grids than the panel could show otherwise.
- Consolidated flag color logic and made references to flag colors consistent.
- Removed Key Moments grid from available grid selection for right panel in User Settings.
- Added logic to prevent views from reloading if user closed the User Settings form without making any changes.