### PR TITLE
Bugfix - ToNext column in Leaderboard truncates long value

### DIFF
--- a/src/apps/rNascar23/MainForm.cs
+++ b/src/apps/rNascar23/MainForm.cs
@@ -1515,7 +1515,7 @@ namespace rNascar23
                 switch (gridView.Settings.ApiSource)
                 {
                     case ApiSources.LoopData:
-                        ((IGridView<rNascar23.LoopData.Models.Driver>)gridView).Data = _formState.EventStatistics.drivers;
+                        ((IGridView<LoopData.Models.Driver>)gridView).Data = _formState.EventStatistics.drivers;
                         break;
                     case ApiSources.Flags:
                         ((IGridView<FlagState>)gridView).Data = _formState.FlagStates;
@@ -2531,6 +2531,8 @@ namespace rNascar23
 
             LoadStateFromJsonFile(jsonFileName);
 
+            File.Delete(jsonFileName);
+
             await UpdateDataViewsAsync();
         }
 
@@ -2539,8 +2541,6 @@ namespace rNascar23
             var json = File.ReadAllText(jsonFileName);
 
             _formState = JsonConvert.DeserializeObject<FormState>(json);
-
-            File.Delete(jsonFileName);
         }
 
         private void UpdateReplayLabel(EventReplay replay, int index)

--- a/src/apps/rNascar23/Views/LeaderboardGridView.Designer.cs
+++ b/src/apps/rNascar23/Views/LeaderboardGridView.Designer.cs
@@ -48,9 +48,12 @@
             this.Grid.GridColor = System.Drawing.Color.Black;
             this.Grid.Location = new System.Drawing.Point(0, 25);
             this.Grid.Name = "Grid";
+            this.Grid.RowTemplate.Height = 24;
+            this.Grid.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.Grid.Size = new System.Drawing.Size(825, 392);
             this.Grid.TabIndex = 3;
             this.Grid.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.Grid_DataBindingComplete);
+            this.Grid.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.Grid_RowsAdded);
             // 
             // TitleLabel
             // 

--- a/src/apps/rNascar23/Views/LeaderboardGridView.cs
+++ b/src/apps/rNascar23/Views/LeaderboardGridView.cs
@@ -400,30 +400,35 @@ namespace rNascar23.Views
                 dataGridView.RowTemplate.Height = 28;
             }
 
-            DataGridViewTextBoxColumn Column1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewCheckBoxColumn Column8 = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            DataGridViewTextBoxColumn Column9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            if (FontOverride == null)
+            {
+                dataGridView.RowTemplate.Height = 28;
+            }
 
-            DataGridViewTextBoxColumn Column13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewTextBoxColumn Column18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            DataGridViewImageColumn colManufacturerImage = new System.Windows.Forms.DataGridViewImageColumn();
-            DataGridViewImageColumn colVehicleStatusImage = new System.Windows.Forms.DataGridViewImageColumn();
-            DataGridViewImageColumn colCarNumberImage = new System.Windows.Forms.DataGridViewImageColumn();
+            DataGridViewTextBoxColumn Column1 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column2 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column3 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column4 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column5 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column6 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column7 = new DataGridViewTextBoxColumn();
+            DataGridViewCheckBoxColumn Column8 = new DataGridViewCheckBoxColumn();
+            DataGridViewTextBoxColumn Column9 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column10 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column11 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column12 = new DataGridViewTextBoxColumn();
 
-            dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[]
+            DataGridViewTextBoxColumn Column13 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column14 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column15 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column16 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column17 = new DataGridViewTextBoxColumn();
+            DataGridViewTextBoxColumn Column18 = new DataGridViewTextBoxColumn();
+            DataGridViewImageColumn colManufacturerImage = new DataGridViewImageColumn();
+            DataGridViewImageColumn colVehicleStatusImage = new DataGridViewImageColumn();
+            DataGridViewImageColumn colCarNumberImage = new DataGridViewImageColumn();
+
+            dataGridView.Columns.AddRange(new DataGridViewColumn[]
             {
                 Column1,
                 colCarNumberImage,
@@ -500,7 +505,7 @@ namespace rNascar23.Views
 
             Column7.HeaderText = "To Next";
             Column7.Name = "DeltaNext";
-            Column7.Width = 65;
+            Column7.Width = 70;
             Column7.DefaultCellStyle.Font = gridFont;
             Column7.DataPropertyName = "DeltaNext";
 
@@ -608,8 +613,6 @@ namespace rNascar23.Views
             return dataGridView;
         }
 
-        #endregion
-
         private void Grid_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
         {
             if (FontOverride != null)
@@ -628,5 +631,15 @@ namespace rNascar23.Views
                 Grid.Columns["CarManufacturerImage"].Visible = false;
             }
         }
+
+        private void Grid_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)
+        {
+            for (int i = e.RowIndex; i < e.RowIndex + e.RowCount; i++)
+            {
+                Grid.Rows[i].DividerHeight = 8;
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
- Fixed an issue where the value in the ToNext column in the leaderboard was being truncated if it had a negative sign and 3 digits after the decimal place.
- Increased leaderboard row height slightly when not using user-defined font.
- Cleaned up reduntant namespace declarations.