### PR TITLE
Added time displays

### DIFF
--- a/src/apps/rNascar23.RaceLogger/Logger.cs
+++ b/src/apps/rNascar23.RaceLogger/Logger.cs
@@ -140,16 +140,18 @@ namespace rNascar23.RaceLogger
 
                 _formState.LiveFeed = await _liveFeedRepository.GetLiveFeedAsync();
 
-                if (_formState.LiveFeed.TimeOfDayOs == _lastLiveFeedTimestamp)
+                var liveFeedTimestamp = DateTime.Parse(_formState.LiveFeed.TimeOfDayOs);
+
+                if (liveFeedTimestamp == _lastLiveFeedTimestamp)
                     return false;
 
                 var timeSinceLastUpdate = _lastLiveFeedTimestamp == DateTime.MinValue ?
                     new TimeSpan() :
-                    _formState.LiveFeed.TimeOfDayOs.Subtract(_lastLiveFeedTimestamp);
+                    liveFeedTimestamp.Subtract(_lastLiveFeedTimestamp);
 
                 WriteMessage($"Update found. Elapsed Time: {_formState.LiveFeed.ElapsedTime}. Time since last update: {timeSinceLastUpdate.ToString("mm\\.ss")} (mm.ss).");
 
-                _lastLiveFeedTimestamp = _formState.LiveFeed.TimeOfDayOs;
+                _lastLiveFeedTimestamp = liveFeedTimestamp;
 
                 if (!DataHasChanges(_formState))
                 {

--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.Designer.cs
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.Designer.cs
@@ -89,6 +89,9 @@
             this.label12 = new System.Windows.Forms.Label();
             this.lblHelp = new System.Windows.Forms.Label();
             this.tabPage4 = new System.Windows.Forms.TabPage();
+            this.lblOverrideFont = new System.Windows.Forms.Label();
+            this.btnSetFont = new System.Windows.Forms.Button();
+            this.chkLowRes = new System.Windows.Forms.CheckBox();
             this.lblDataDelay = new System.Windows.Forms.Label();
             this.txtDataDelay = new System.Windows.Forms.TextBox();
             this.chkDelayDataUpdates = new System.Windows.Forms.CheckBox();
@@ -97,9 +100,7 @@
             this.label18 = new System.Windows.Forms.Label();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.tabPage3 = new System.Windows.Forms.TabPage();
-            this.chkLowRes = new System.Windows.Forms.CheckBox();
-            this.btnSetFont = new System.Windows.Forms.Button();
-            this.lblOverrideFont = new System.Windows.Forms.Label();
+            this.chkDisplayTimes = new System.Windows.Forms.CheckBox();
             this.panel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -756,6 +757,7 @@
             // 
             // tabPage4
             // 
+            this.tabPage4.Controls.Add(this.chkDisplayTimes);
             this.tabPage4.Controls.Add(this.lblOverrideFont);
             this.tabPage4.Controls.Add(this.btnSetFont);
             this.tabPage4.Controls.Add(this.chkLowRes);
@@ -783,6 +785,37 @@
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "UI Options";
             this.tabPage4.UseVisualStyleBackColor = true;
+            // 
+            // lblOverrideFont
+            // 
+            this.lblOverrideFont.AutoSize = true;
+            this.lblOverrideFont.Location = new System.Drawing.Point(34, 449);
+            this.lblOverrideFont.Name = "lblOverrideFont";
+            this.lblOverrideFont.Size = new System.Drawing.Size(15, 20);
+            this.lblOverrideFont.TabIndex = 29;
+            this.lblOverrideFont.Text = "-";
+            // 
+            // btnSetFont
+            // 
+            this.btnSetFont.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnSetFont.Location = new System.Drawing.Point(234, 418);
+            this.btnSetFont.Name = "btnSetFont";
+            this.btnSetFont.Size = new System.Drawing.Size(75, 23);
+            this.btnSetFont.TabIndex = 28;
+            this.btnSetFont.Text = "Set Font";
+            this.btnSetFont.UseVisualStyleBackColor = true;
+            this.btnSetFont.Click += new System.EventHandler(this.btnSetFont_Click);
+            // 
+            // chkLowRes
+            // 
+            this.chkLowRes.AutoSize = true;
+            this.chkLowRes.Location = new System.Drawing.Point(14, 418);
+            this.chkLowRes.Name = "chkLowRes";
+            this.chkLowRes.Size = new System.Drawing.Size(214, 24);
+            this.chkLowRes.TabIndex = 27;
+            this.chkLowRes.Text = "Use Low Resolution Settings";
+            this.chkLowRes.UseVisualStyleBackColor = true;
+            this.chkLowRes.CheckStateChanged += new System.EventHandler(this.chkLowRes_CheckStateChanged);
             // 
             // lblDataDelay
             // 
@@ -876,36 +909,15 @@
             this.tabPage3.Text = "Folders";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
-            // chkLowRes
+            // chkDisplayTimes
             // 
-            this.chkLowRes.AutoSize = true;
-            this.chkLowRes.Location = new System.Drawing.Point(14, 418);
-            this.chkLowRes.Name = "chkLowRes";
-            this.chkLowRes.Size = new System.Drawing.Size(214, 24);
-            this.chkLowRes.TabIndex = 27;
-            this.chkLowRes.Text = "Use Low Resolution Settings";
-            this.chkLowRes.UseVisualStyleBackColor = true;
-            this.chkLowRes.CheckStateChanged += new System.EventHandler(this.chkLowRes_CheckStateChanged);
-            // 
-            // btnSetFont
-            // 
-            this.btnSetFont.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnSetFont.Location = new System.Drawing.Point(234, 418);
-            this.btnSetFont.Name = "btnSetFont";
-            this.btnSetFont.Size = new System.Drawing.Size(75, 23);
-            this.btnSetFont.TabIndex = 28;
-            this.btnSetFont.Text = "Set Font";
-            this.btnSetFont.UseVisualStyleBackColor = true;
-            this.btnSetFont.Click += new System.EventHandler(this.btnSetFont_Click);
-            // 
-            // lblOverrideFont
-            // 
-            this.lblOverrideFont.AutoSize = true;
-            this.lblOverrideFont.Location = new System.Drawing.Point(34, 449);
-            this.lblOverrideFont.Name = "lblOverrideFont";
-            this.lblOverrideFont.Size = new System.Drawing.Size(15, 20);
-            this.lblOverrideFont.TabIndex = 29;
-            this.lblOverrideFont.Text = "-";
+            this.chkDisplayTimes.AutoSize = true;
+            this.chkDisplayTimes.Location = new System.Drawing.Point(14, 449);
+            this.chkDisplayTimes.Name = "chkDisplayTimes";
+            this.chkDisplayTimes.Size = new System.Drawing.Size(220, 24);
+            this.chkDisplayTimes.TabIndex = 30;
+            this.chkDisplayTimes.Text = "Display Local and Track Time";
+            this.chkDisplayTimes.UseVisualStyleBackColor = true;
             // 
             // UserSettingsDialog
             // 
@@ -1018,5 +1030,6 @@
         private System.Windows.Forms.Label lblOverrideFont;
         private System.Windows.Forms.Button btnSetFont;
         private System.Windows.Forms.CheckBox chkLowRes;
+        private System.Windows.Forms.CheckBox chkDisplayTimes;
     }
 }

--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.cs
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.cs
@@ -118,6 +118,8 @@ namespace rNascar23.Dialogs
             chkUseGraphicalNumbers.Checked = settings.UseGraphicalCarNumbers;
             chkUseDarkTheme.Checked = settings.UseDarkTheme;
             chkAutoUpdateEnabledOnStartup.Checked = settings.AutoUpdateEnabledOnStart;
+            chkDisplayTimes.Checked = settings.DisplayTimeDifference;
+
             chkDelayDataUpdates.Checked = settings.DataDelayInSeconds.HasValue;
             if (settings.DataDelayInSeconds.HasValue)
             {
@@ -471,6 +473,7 @@ namespace rNascar23.Dialogs
             _userSettings.UseGraphicalCarNumbers = chkUseGraphicalNumbers.Checked;
             _userSettings.UseDarkTheme = chkUseDarkTheme.Checked;
             _userSettings.AutoUpdateEnabledOnStart = chkAutoUpdateEnabledOnStartup.Checked;
+            _userSettings.DisplayTimeDifference = chkDisplayTimes.Checked;
 
             _userSettings.FavoriteDrivers = new List<string>();
 

--- a/src/apps/rNascar23/Dialogs/UserSettingsDialog.resx
+++ b/src/apps/rNascar23/Dialogs/UserSettingsDialog.resx
@@ -181,9 +181,6 @@
         gg==
 </value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="btnBackupDirectory.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6

--- a/src/apps/rNascar23/MainForm.Designer.cs
+++ b/src/apps/rNascar23/MainForm.Designer.cs
@@ -98,6 +98,8 @@
             this.pnlPitStops = new System.Windows.Forms.Panel();
             this.pnlLoading = new System.Windows.Forms.Panel();
             this.lblLoading = new System.Windows.Forms.Label();
+            this.lblTrackTime = new System.Windows.Forms.ToolStripLabel();
+            this.lblLocalTime = new System.Windows.Forms.ToolStripLabel();
             this.pnlHeader.SuspendLayout();
             this.pnlEventInfo.SuspendLayout();
             this.pnlFlagGreenYellow.SuspendLayout();
@@ -146,9 +148,10 @@
             // 
             this.lblStageLaps.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblStageLaps.AutoSize = true;
+            this.lblStageLaps.BackColor = System.Drawing.Color.Black;
             this.lblStageLaps.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblStageLaps.ForeColor = System.Drawing.Color.WhiteSmoke;
-            this.lblStageLaps.Location = new System.Drawing.Point(1150, 2);
+            this.lblStageLaps.ForeColor = System.Drawing.Color.LightGray;
+            this.lblStageLaps.Location = new System.Drawing.Point(1195, 2);
             this.lblStageLaps.Name = "lblStageLaps";
             this.lblStageLaps.Size = new System.Drawing.Size(0, 16);
             this.lblStageLaps.TabIndex = 13;
@@ -158,9 +161,10 @@
             // 
             this.lblRaceLaps.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblRaceLaps.AutoSize = true;
+            this.lblRaceLaps.BackColor = System.Drawing.Color.Black;
             this.lblRaceLaps.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblRaceLaps.ForeColor = System.Drawing.Color.WhiteSmoke;
-            this.lblRaceLaps.Location = new System.Drawing.Point(939, 2);
+            this.lblRaceLaps.Location = new System.Drawing.Point(1046, 2);
             this.lblRaceLaps.Name = "lblRaceLaps";
             this.lblRaceLaps.Size = new System.Drawing.Size(0, 16);
             this.lblRaceLaps.TabIndex = 12;
@@ -247,7 +251,7 @@
             // 
             this.logFileToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("logFileToolStripMenuItem.Image")));
             this.logFileToolStripMenuItem.Name = "logFileToolStripMenuItem";
-            this.logFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.logFileToolStripMenuItem.Size = new System.Drawing.Size(138, 22);
             this.logFileToolStripMenuItem.Text = "Log File";
             this.logFileToolStripMenuItem.Click += new System.EventHandler(this.logFileToolStripMenuItem_Click);
             // 
@@ -255,7 +259,7 @@
             // 
             this.patchNotesToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("patchNotesToolStripMenuItem.Image")));
             this.patchNotesToolStripMenuItem.Name = "patchNotesToolStripMenuItem";
-            this.patchNotesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.patchNotesToolStripMenuItem.Size = new System.Drawing.Size(138, 22);
             this.patchNotesToolStripMenuItem.Text = "Patch Notes";
             this.patchNotesToolStripMenuItem.Click += new System.EventHandler(this.patchNotesToolStripMenuItem_Click);
             // 
@@ -381,7 +385,7 @@
             // 
             this.audioChannelsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("audioChannelsToolStripMenuItem.Image")));
             this.audioChannelsToolStripMenuItem.Name = "audioChannelsToolStripMenuItem";
-            this.audioChannelsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.audioChannelsToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
             this.audioChannelsToolStripMenuItem.Text = "Audio Channels";
             this.audioChannelsToolStripMenuItem.Click += new System.EventHandler(this.audioChannelsToolStripMenuItem_Click);
             // 
@@ -389,20 +393,20 @@
             // 
             this.inCarCamerasToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("inCarCamerasToolStripMenuItem.Image")));
             this.inCarCamerasToolStripMenuItem.Name = "inCarCamerasToolStripMenuItem";
-            this.inCarCamerasToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.inCarCamerasToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
             this.inCarCamerasToolStripMenuItem.Text = "In-Car Cameras";
             this.inCarCamerasToolStripMenuItem.Click += new System.EventHandler(this.inCarCamerasToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(177, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(155, 6);
             // 
             // multiViewToolStripMenuItem
             // 
             this.multiViewToolStripMenuItem.Image = global::rNascar23.Properties.Resources.MultiViewGrid;
             this.multiViewToolStripMenuItem.Name = "multiViewToolStripMenuItem";
-            this.multiViewToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.multiViewToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
             this.multiViewToolStripMenuItem.Text = "MultiView";
             this.multiViewToolStripMenuItem.Click += new System.EventHandler(this.multiViewToolStripMenuItem_Click);
             // 
@@ -517,7 +521,9 @@
             this.tsbExit,
             this.tsbAutoUpdate,
             this.tsbFullScreen,
-            this.btnPitStopsView});
+            this.btnPitStopsView,
+            this.lblTrackTime,
+            this.lblLocalTime});
             this.toolStrip1.Location = new System.Drawing.Point(0, 24);
             this.toolStrip1.Name = "toolStrip1";
             this.toolStrip1.Size = new System.Drawing.Size(1350, 25);
@@ -745,6 +751,32 @@
             this.lblLoading.TabIndex = 0;
             this.lblLoading.Text = "Loading...";
             // 
+            // lblTrackTime
+            // 
+            this.lblTrackTime.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.lblTrackTime.AutoSize = false;
+            this.lblTrackTime.AutoToolTip = true;
+            this.lblTrackTime.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.lblTrackTime.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            this.lblTrackTime.ForeColor = System.Drawing.Color.Silver;
+            this.lblTrackTime.Margin = new System.Windows.Forms.Padding(0, 1, 5, 2);
+            this.lblTrackTime.Name = "lblTrackTime";
+            this.lblTrackTime.Size = new System.Drawing.Size(170, 22);
+            this.lblTrackTime.Text = "Track: -";
+            // 
+            // lblLocalTime
+            // 
+            this.lblLocalTime.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.lblLocalTime.AutoSize = false;
+            this.lblLocalTime.AutoToolTip = true;
+            this.lblLocalTime.BackColor = System.Drawing.Color.Black;
+            this.lblLocalTime.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.lblLocalTime.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            this.lblLocalTime.ForeColor = System.Drawing.Color.LightGray;
+            this.lblLocalTime.Name = "lblLocalTime";
+            this.lblLocalTime.Size = new System.Drawing.Size(150, 22);
+            this.lblLocalTime.Text = "Local: -";
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -860,6 +892,8 @@
         private System.Windows.Forms.Label lblLoading;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem multiViewToolStripMenuItem;
+        private System.Windows.Forms.ToolStripLabel lblTrackTime;
+        private System.Windows.Forms.ToolStripLabel lblLocalTime;
     }
 }
 

--- a/src/apps/rNascar23/MainForm.resx
+++ b/src/apps/rNascar23/MainForm.resx
@@ -124,24 +124,6 @@
     <value>166, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="audioChannelsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAABwSURBVDhP5ZLBDcAgCAAdoaN0BnZhLkbsCAiEVkJIlHcv4YPefXTsYOZb5pExfH2G3DeZiBgR
-        e4EstwKVvA3YaSDLR4Es5Im4ttBlJVXz50DEtYXvP9rPGJF7/Y+UqSKtgJIj7YDyRswWAODyI2GMCRMW
-        hab1VqjaAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="inCarCamerasToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADMSURBVDhPvVGxDYMwEMwoGSEjRGzhjoKe3lUqprDECNnA
-        LOGeAVzQuf38mTcY4iKAlJMO68Tf2WffiOgS5w8jhFAzB2HPfDLforE+4uAeCOCfL+ccaa2pbVsyxpD3
-        nrquixordDFEAialFFVVtbBpmo1GCE4ithUSsBkuESfhuUFsKyRg3O+IOrlGLZ7rxbZCAuq8s7UWw9GU
-        7oT1xLyLLXqY41LhAKMx6Z/vAEwmvBgqnwpAnVwfDtjr/wdcrgAWL/EAv5/xDOagMH4Aj6xYmLWTdyEA
-        AAAASUVORK5CYII=
-</value>
-  </data>
   <data name="exitToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
@@ -163,7 +145,7 @@
   <data name="patchNotesToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
-        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7CAAAOwgEVKEqAAAAAdElE
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7BAAAOwQG4kWvtAAAAdElE
         QVQ4T2OgGlBUVHwAxP+xYQUFhY/y8vIOUKXYAUihnJycJDYMNeibkpKSE1Q5JiDCAPyGwAxgiN31Hxmj
         GQD2DlQLKoAZQAiD1EG1oAKqGYDuBWRMlAGEMO0NwOZ0GCbKAEKYpgbgzAto+AFUy6AADAwA+9+IPzit
         HFYAAAAASUVORK5CYII=
@@ -179,6 +161,23 @@
         CC9uYm4BamksbxssIUe6r46pKRKaDjx97uvkqpXGdNdA5G8NNOSrBmPQcDS9fHsFvms1sVjcnTn9Io00
         lq8Mcv2I5xK5yVxQrBwnOCF+o/G+ZZ1BaEkKHRM/0DTFgicPzWkXKss6I7lepClT20XyfXPFzmkHdMpr
         yzYN8gJUvV5vD/9M4fYqP34r3jZEetj1n+nG6b+2IPgAzHGHcFUSC1YAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="audioChannelsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAHBJREFUOE/l
+        ksENwCAIAB2ho3QGdmEuRuwICIRWQkiUdy/hg959dOxg5lvmkTF8fYbcN5mIGBF7gSy3ApW8DdhpIMtH
+        gSzkibi20GUlVfPnQMS1he8/2s8YkXv9j5SpIq2AkiPtgPJGzBYA4PIjYYwJExaFpvVWqNoAAAAASUVO
+        RK5CYII=
+</value>
+  </data>
+  <data name="inCarCamerasToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAAMxJREFUOE+9UbENgzAQzCgZISNEbOGOgp7eVSqmsMQI2cAs4Z4BXNC5/fyZNxji
+        IoCUkw7rxN/ZZ9+I6BLnDyOEUDMHYc98Mt+isT7i4B4I4J8v5xxpraltWzLGkPeeuq6LGit0MUQCJqUU
+        VVW1sGmajUYITiK2FRKwGS4RJ+G5QWwrJGDc74g6uUYtnuvFtkIC6ryztRbD0ZTuhPXEvIstepjjUuEA
+        ozHpn+8ATCa8GCqfCkCdXB8O2Ov/B1yuABYv8QC/n/EM5qAwfgCPrFiYtZN3IQAAAABJRU5ErkJggg==
 </value>
   </data>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/libraries/Common/rNasar23.Common/UserSettings.cs
+++ b/src/libraries/Common/rNasar23.Common/UserSettings.cs
@@ -17,6 +17,7 @@ namespace rNascar23.Common
         public bool UseDarkTheme { get; set; } = false;
         public bool AutoUpdateEnabledOnStart { get; set; } = true;
         public bool UseLowScreenResolutionSizes { get; set; } = true;
+        public bool DisplayTimeDifference { get; set; } = false;
         public string OverrideFontName { get; set; }
         public float? OverrideFontSize { get; set; }
         public int? OverrideFontStyle { get; set; }

--- a/src/libraries/LiveFeed/rNascar23.LiveFeed/Models/LiveFeed.cs
+++ b/src/libraries/LiveFeed/rNascar23.LiveFeed/Models/LiveFeed.cs
@@ -16,7 +16,7 @@ namespace rNascar23.LiveFeeds.Models
         public string RunName { get; set; }
         public int SeriesId { get; set; }
         public int TimeOfDay { get; set; }
-        public DateTime TimeOfDayOs { get; set; }
+        public string TimeOfDayOs { get; set; }
         public int TrackId { get; set; }
         public float TrackLength { get; set; }
         public string TrackName { get; set; }

--- a/src/libraries/LiveFeed/rNascar23.Service.LiveFeeds/Data/Models/LiveFeedModel.cs
+++ b/src/libraries/LiveFeed/rNascar23.Service.LiveFeeds/Data/Models/LiveFeedModel.cs
@@ -15,7 +15,7 @@ namespace rNascar23.Service.LiveFeeds.Data.Models
         public string run_name { get; set; }
         public int series_id { get; set; }
         public int time_of_day { get; set; }
-        public DateTime time_of_day_os { get; set; }
+        public string time_of_day_os { get; set; }
         public int track_id { get; set; }
         public float track_length { get; set; }
         public string track_name { get; set; }


### PR DESCRIPTION
Added a new user setting, "Display Local and Track Time", and two new labels to the toolbar at the top of the form, just to the left of the Full Screen button. These will display the track's local time and the user's local time, so any difference in time zone can be noted.