### PR TITLE
Nullable Object error on new install or patch

### DIFF
--- a/src/apps/rNascar23/Patch Notes.txt
+++ b/src/apps/rNascar23/Patch Notes.txt
@@ -1,4 +1,17 @@
-﻿Version 0.3.0.29
+﻿Version 0.3.0.30
+====================================
+
+Bug Fix
+-----------
+- Nullable Object error after patch to version 0.3.0.28
+	The default value for the UseLowScreenResolutionSizes was set to true, but no default font was defined. 
+	This caused an error when the user tried to load the leaderboard if they didn't edit and save their user settings first.
+	
+	- Updated the default value for UseLowScreenResolutionSizes to be false. 
+	- Added default values for the override font in the default user settings file that gets created on first run.
+
+
+Version 0.3.0.29
 ====================================
 
 New Features

--- a/src/libraries/Common/rNasar23.Common/UserSettings.cs
+++ b/src/libraries/Common/rNasar23.Common/UserSettings.cs
@@ -16,11 +16,11 @@ namespace rNascar23.Common
         public bool UseGraphicalCarNumbers { get; set; } = false;
         public bool UseDarkTheme { get; set; } = false;
         public bool AutoUpdateEnabledOnStart { get; set; } = true;
-        public bool UseLowScreenResolutionSizes { get; set; } = true;
+        public bool UseLowScreenResolutionSizes { get; set; } = false;
         public bool DisplayTimeDifference { get; set; } = false;
-        public string OverrideFontName { get; set; }
-        public float? OverrideFontSize { get; set; }
-        public int? OverrideFontStyle { get; set; }
+        public string OverrideFontName { get; set; } = "Arial";
+        public float? OverrideFontSize { get; set; } = 10;
+        public int? OverrideFontStyle { get; set; } = 0;
         public IList<int> RaceViewBottomGrids { get; set; } = new List<int>();
         public IList<int> RaceViewRightGrids { get; set; } = new List<int>();
         public IList<int> QualifyingViewBottomGrids { get; set; } = new List<int>();


### PR DESCRIPTION
The default value for the UseLowScreenResolutionSizes was set to true, but no default font was defined. This caused an error when the user tried to load the leaderboard if they didn't edit and save their user settings first.

Updated the default value for UseLowScreenResolutionSizes to be false, and added default values for the override font in the default user settings file that gets created on first run.